### PR TITLE
Update to latest dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["config", "api-bindings"]
 keywords = ["Flagsmith", "feature-flag", "remote-config"]
 
 [dependencies]
-tokio = {version = "1.43"}
-futures = {version = "0.3"}
-serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.43", default-features = false }
+futures = { version = "0.3" }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12.12", features = ["json"] }
+reqwest = { version = "0.12.12", default-features = false, features = ["json"] }
 url = "2.1"
-chrono = { version = "0.4"}
+chrono = { version = "0.4", default-features = false }
 log = "0.4"
 flagsmith-flag-engine = "0.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "flagsmith-async"
-version = "1.0.4"
+version = "1.1.0"
 authors = ["Gagan Trivedi <gagan.trivedi@flagsmith.com>", "Michał Buczko <michal@buczko.pl>"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 description = "Flagsmith SDK for Rust"
 homepage = "https://flagsmith.com/"
@@ -11,20 +11,17 @@ readme = "README.md"
 categories = ["config", "api-bindings"]
 keywords = ["Flagsmith", "feature-flag", "remote-config"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-tokio = {version = "1.17"}
+tokio = {version = "1.43"}
 futures = {version = "0.3"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12.12", features = ["json"] }
 url = "2.1"
 chrono = { version = "0.4"}
 log = "0.4"
-
-flagsmith-flag-engine = "0.1.1"
+flagsmith-flag-engine = "0.4.0"
 
 [dev-dependencies]
-httpmock = "0.6"
-rstest = "0.12.0"
+httpmock = "0.7.0"
+rstest = "0.25.0"

--- a/src/flagsmith.rs
+++ b/src/flagsmith.rs
@@ -1,9 +1,9 @@
 use flagsmith_flag_engine::engine;
-use flagsmith_flag_engine::environments::builders::build_environment_struct;
 use flagsmith_flag_engine::environments::Environment;
+use flagsmith_flag_engine::environments::builders::build_environment_struct;
 use flagsmith_flag_engine::identities::{Identity, Trait};
-use flagsmith_flag_engine::segments::evaluator::get_identity_segments;
 use flagsmith_flag_engine::segments::Segment;
+use flagsmith_flag_engine::segments::evaluator::get_identity_segments;
 use futures::lock::Mutex;
 use log::debug;
 use reqwest::header::{self, HeaderMap};
@@ -117,7 +117,8 @@ impl Flagsmith {
                         Err(TryRecvError::Empty) => {}
                     }
 
-                    let environment = get_environment_from_api(&client, environment_url.clone()).await;
+                    let environment =
+                        get_environment_from_api(&client, environment_url.clone()).await;
 
                     if let Err(err) = environment {
                         log::error!("updating environment document failed: {}", err);
@@ -126,7 +127,8 @@ impl Flagsmith {
                         data.environment = Some(environment.unwrap());
                         drop(data);
                     }
-                    tokio::time::sleep(Duration::from_millis(environment_refresh_interval_mills)).await;
+                    tokio::time::sleep(Duration::from_millis(environment_refresh_interval_mills))
+                        .await;
                 }
             });
         }

--- a/src/flagsmith/analytics.rs
+++ b/src/flagsmith/analytics.rs
@@ -3,7 +3,7 @@ use reqwest::header::HeaderMap;
 use serde_json;
 use std::collections::HashMap;
 use std::sync::mpsc::{SyncSender, TryRecvError};
-use std::sync::{mpsc, Arc};
+use std::sync::{Arc, mpsc};
 use tokio::sync::RwLock;
 
 static ANALYTICS_TIMER_IN_MILLI: u64 = 10 * 1000;

--- a/src/flagsmith/models.rs
+++ b/src/flagsmith/models.rs
@@ -1,4 +1,4 @@
-use crate::flagsmith_async::analytics::AnalyticsProcessor;
+use crate::flagsmith::analytics::AnalyticsProcessor;
 use core::f64;
 use flagsmith_flag_engine::features::FeatureState;
 use flagsmith_flag_engine::types::{FlagsmithValue, FlagsmithValueType};
@@ -74,7 +74,7 @@ impl Flag {
             FlagsmithValueType::Integer => Some(self.value.value.parse::<i32>().ok()?),
             _ => None,
         }
-    }    
+    }
     pub fn value_as_i64(&self) -> Option<i64> {
         match self.value.value_type {
             FlagsmithValueType::Integer => Some(self.value.value.parse::<i64>().ok()?),
@@ -110,6 +110,7 @@ impl Flags {
             default_flag_handler,
         }
     }
+
     pub fn from_api_flags(
         api_flags: &Vec<serde_json::Value>,
         analytics_processor: Option<AnalyticsProcessor>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod error;
-pub mod flagsmith_async;
-pub use crate::flagsmith_async::models::Flag;
-pub use crate::flagsmith_async::{Flagsmith, FlagsmithOptions};
+pub mod flagsmith;
+pub use crate::flagsmith::models::Flag;
+pub use crate::flagsmith::{Flagsmith, FlagsmithOptions};
+
+pub use flagsmith_flag_engine as flag_engine;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,13 +7,13 @@ use rstest::*;
 
 mod fixtures;
 
+use fixtures::ENVIRONMENT_KEY;
 use fixtures::default_flag_handler;
 use fixtures::environment_json;
 use fixtures::flags_json;
 use fixtures::identities_json;
 use fixtures::local_eval_flagsmith;
 use fixtures::mock_server;
-use fixtures::ENVIRONMENT_KEY;
 
 #[rstest]
 #[tokio::test]
@@ -480,7 +480,10 @@ async fn test_flagsmith_api_error_is_returned_if_something_goes_wrong_with_the_r
 
     // When
     let err = flagsmith.get_environment_flags().await.err().unwrap();
-    assert_eq!(err.kind, flagsmith_async::error::ErrorKind::FlagsmithAPIError);
+    assert_eq!(
+        err.kind,
+        flagsmith_async::error::ErrorKind::FlagsmithAPIError
+    );
 }
 
 #[rstest]
@@ -512,7 +515,10 @@ async fn test_flagsmith_client_error_is_returned_if_get_flag_is_called_with_a_fl
         .unwrap();
 
     // Then
-    assert_eq!(err.kind, flagsmith_async::error::ErrorKind::FlagsmithAPIError);
+    assert_eq!(
+        err.kind,
+        flagsmith_async::error::ErrorKind::FlagsmithAPIError
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
This updates the dependencies to the latest version, renames the `flagsmith_async` module to `flagsmith` and re-exports the `flag_engine` crate for easier access.